### PR TITLE
Remove scheduled-docs specific format from schedule-badge example

### DIFF
--- a/_extensions/course-website-ejs/schedule-badge/schedule-example.yml
+++ b/_extensions/course-website-ejs/schedule-badge/schedule-example.yml
@@ -1,8 +1,3 @@
-scheduled-docs:
-  draft-after: "2024-08-24"
-  timezone: "-07:00"
-  debug: true
-  schedule:
     - week: 1
       days:
         - date: "2024-08-23"


### PR DESCRIPTION
Per issue #2, it makes more sense to have the schedule template example not depend on scheduled-docs.